### PR TITLE
Fix const check pattern

### DIFF
--- a/generate/update.php
+++ b/generate/update.php
@@ -54,7 +54,7 @@
 			++$Count;
 			
 			$IsCommentOpening = substr( $Line, 0, 2 ) === '/*';
-			$IsFunction = preg_match( '/^(stock|functag|native|forward|methodmap)(?!\s*const)/', $Line ) === 1;
+			$IsFunction = preg_match( '/^(stock|functag|native|forward|methodmap)(?!\s*const\s)/', $Line ) === 1;
 			
 			if( $FunctionUntilNextCommentBlock )
 			{


### PR DESCRIPTION
If function name starting with 'const*', like "stock constraint_offset(low, high, seed, offset)", its parsing as constant. This change will fix it.